### PR TITLE
Dynatrace Domain change

### DIFF
--- a/scripts/2-defineCredentials.sh
+++ b/scripts/2-defineCredentials.sh
@@ -24,13 +24,13 @@ clear
 echo "==================================================================="
 echo -e "${YLW}Please enter the values as requested below: ${NC}"
 echo "==================================================================="
-read -p "Dynatrace Tenant ID (foo.dynatracedomain.com) (current: $DT_TENANT_BASE_URL) : " DT_TENANT_BASE_URL_NEW
-read -p "Dynatrace API Token                           (current: $DT_API_TOKEN) : " DT_API_TOKEN_NEW
-read -p "Dynatrace PaaS Token                          (current: $DT_PAAS_TOKEN) : " DT_PAAS_TOKEN_NEW
-read -p "GitHub User Name                              (current: $GITHUB_USER_NAME) : " GITHUB_USER_NAME_NEW
-read -p "GitHub Personal Access Token                  (current: $GITHUB_PERSONAL_ACCESS_TOKEN) : " GITHUB_PERSONAL_ACCESS_TOKEN_NEW
-read -p "GitHub User Email                             (current: $GITHUB_USER_EMAIL) : " GITHUB_USER_EMAIL_NEW
-read -p "GitHub Organization                           (current: $GITHUB_ORGANIZATION) : " GITHUB_ORGANIZATION_NEW
+read -p "Dynatrace Tenant ID (e.g. abc12345.live.dynatrace.com) (current: $DT_TENANT_BASE_URL) : " DT_TENANT_BASE_URL_NEW
+read -p "Dynatrace API Token                                    (current: $DT_API_TOKEN) : " DT_API_TOKEN_NEW
+read -p "Dynatrace PaaS Token                                   (current: $DT_PAAS_TOKEN) : " DT_PAAS_TOKEN_NEW
+read -p "GitHub User Name                                       (current: $GITHUB_USER_NAME) : " GITHUB_USER_NAME_NEW
+read -p "GitHub Personal Access Token                           (current: $GITHUB_PERSONAL_ACCESS_TOKEN) : " GITHUB_PERSONAL_ACCESS_TOKEN_NEW
+read -p "GitHub User Email                                      (current: $GITHUB_USER_EMAIL) : " GITHUB_USER_EMAIL_NEW
+read -p "GitHub Organization                                    (current: $GITHUB_ORGANIZATION) : " GITHUB_ORGANIZATION_NEW
 echo "==================================================================="
 echo ""
 # set value to new input or default to current value

--- a/scripts/2-defineCredentials.sh
+++ b/scripts/2-defineCredentials.sh
@@ -24,7 +24,7 @@ clear
 echo "==================================================================="
 echo -e "${YLW}Please enter the values as requested below: ${NC}"
 echo "==================================================================="
-read -p "Dynatrace Tenant ID (8-digits) (current: $DT_TENANT_ID) : " DT_TENANT_ID_NEW
+read -p "Dynatrace Tenant ID (foo.dynatracedomain.com) (current: $DT_TENANT_ID) : " DT_TENANT_ID_NEW
 read -p "Dynatrace API Token            (current: $DT_API_TOKEN) : " DT_API_TOKEN_NEW
 read -p "Dynatrace PaaS Token           (current: $DT_PAAS_TOKEN) : " DT_PAAS_TOKEN_NEW
 read -p "GitHub User Name               (current: $GITHUB_USER_NAME) : " GITHUB_USER_NAME_NEW

--- a/scripts/2-defineCredentials.sh
+++ b/scripts/2-defineCredentials.sh
@@ -11,7 +11,7 @@ CREDS=./creds.json
 
 if [ -f "$CREDS" ]
 then
-    export DT_TENANT_ID=$(cat creds.json | jq -r '.dynatraceTenant')
+    export DT_TENANT_BASE_URL=$(cat creds.json | jq -r '.dynatraceBaseURL')
     export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
     export DT_PAAS_TOKEN=$(cat creds.json | jq -r '.dynatracePaaSToken')
     export GITHUB_PERSONAL_ACCESS_TOKEN=$(cat creds.json | jq -r '.githubPersonalAccessToken')
@@ -24,17 +24,17 @@ clear
 echo "==================================================================="
 echo -e "${YLW}Please enter the values as requested below: ${NC}"
 echo "==================================================================="
-read -p "Dynatrace Tenant ID (foo.dynatracedomain.com) (current: $DT_TENANT_ID) : " DT_TENANT_ID_NEW
-read -p "Dynatrace API Token            (current: $DT_API_TOKEN) : " DT_API_TOKEN_NEW
-read -p "Dynatrace PaaS Token           (current: $DT_PAAS_TOKEN) : " DT_PAAS_TOKEN_NEW
-read -p "GitHub User Name               (current: $GITHUB_USER_NAME) : " GITHUB_USER_NAME_NEW
-read -p "GitHub Personal Access Token   (current: $GITHUB_PERSONAL_ACCESS_TOKEN) : " GITHUB_PERSONAL_ACCESS_TOKEN_NEW
-read -p "GitHub User Email              (current: $GITHUB_USER_EMAIL) : " GITHUB_USER_EMAIL_NEW
-read -p "GitHub Organization            (current: $GITHUB_ORGANIZATION) : " GITHUB_ORGANIZATION_NEW
+read -p "Dynatrace Tenant ID (foo.dynatracedomain.com) (current: $DT_TENANT_BASE_URL) : " DT_TENANT_BASE_URL_NEW
+read -p "Dynatrace API Token                           (current: $DT_API_TOKEN) : " DT_API_TOKEN_NEW
+read -p "Dynatrace PaaS Token                          (current: $DT_PAAS_TOKEN) : " DT_PAAS_TOKEN_NEW
+read -p "GitHub User Name                              (current: $GITHUB_USER_NAME) : " GITHUB_USER_NAME_NEW
+read -p "GitHub Personal Access Token                  (current: $GITHUB_PERSONAL_ACCESS_TOKEN) : " GITHUB_PERSONAL_ACCESS_TOKEN_NEW
+read -p "GitHub User Email                             (current: $GITHUB_USER_EMAIL) : " GITHUB_USER_EMAIL_NEW
+read -p "GitHub Organization                           (current: $GITHUB_ORGANIZATION) : " GITHUB_ORGANIZATION_NEW
 echo "==================================================================="
 echo ""
 # set value to new input or default to current value
-DT_TENANT_ID=${DT_TENANT_ID_NEW:-$DT_TENANT_ID}
+DT_TENANT_BASE_URL=${DT_TENANT_BASE_URL_NEW:-$DT_TENANT_BASE_URL}
 DT_API_TOKEN=${DT_API_TOKEN_NEW:-$DT_API_TOKEN}
 DT_PAAS_TOKEN=${DT_PAAS_TOKEN_NEW:-$DT_PAAS_TOKEN}
 GITHUB_USER_NAME=${GITHUB_USER_NAME_NEW:-$GITHUB_USER_NAME}
@@ -43,7 +43,7 @@ GITHUB_USER_EMAIL=${GITHUB_USER_EMAIL_NEW:-$GITHUB_USER_EMAIL}
 GITHUB_ORGANIZATION=${GITHUB_ORGANIZATION_NEW:-$GITHUB_ORGANIZATION}
 
 echo -e "${YLW}Please confirm all are correct: ${NC}"
-echo "Dynatrace Tenant: $DT_TENANT_ID"
+echo "Dynatrace Tenant: $DT_TENANT_BASE_URL"
 echo "Dynatrace API Token: $DT_API_TOKEN"
 echo "Dynatrace PaaS Token: $DT_PAAS_TOKEN"
 echo "GitHub User Name: $GITHUB_USER_NAME"
@@ -58,7 +58,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]
 then
     cp $CREDS $CREDS.bak 2> /dev/null
     rm $CREDS 2> /dev/null
-    cat ./creds.sav | sed 's~DYNATRACE_TENANT_PLACEHOLDER~'"$DT_TENANT_ID"'~' | \
+    cat ./creds.sav | sed 's~DYNATRACE_BASEURL_PLACEHOLDER~'"$DT_TENANT_BASE_URL"'~' | \
       sed 's~DYNATRACE_API_TOKEN~'"$DT_API_TOKEN"'~' | \
       sed 's~DYNATRACE_PAAS_TOKEN~'"$DT_PAAS_TOKEN"'~' | \
       sed 's~GITHUB_USER_NAME_PLACEHOLDER~'"$GITHUB_USER_NAME"'~' | \

--- a/scripts/2-defineCredentials.sh
+++ b/scripts/2-defineCredentials.sh
@@ -11,7 +11,7 @@ CREDS=./creds.json
 
 if [ -f "$CREDS" ]
 then
-    export DT_TENANT_BASE_URL=$(cat creds.json | jq -r '.dynatraceBaseURL')
+    export DT_TENANT_HOSTNAME=$(cat creds.json | jq -r '.dynatraceHostName')
     export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
     export DT_PAAS_TOKEN=$(cat creds.json | jq -r '.dynatracePaaSToken')
     export GITHUB_PERSONAL_ACCESS_TOKEN=$(cat creds.json | jq -r '.githubPersonalAccessToken')
@@ -24,7 +24,7 @@ clear
 echo "==================================================================="
 echo -e "${YLW}Please enter the values as requested below: ${NC}"
 echo "==================================================================="
-read -p "Dynatrace Tenant ID (e.g. abc12345.live.dynatrace.com) (current: $DT_TENANT_BASE_URL) : " DT_TENANT_BASE_URL_NEW
+read -p "Dynatrace Tenant ID (e.g. abc12345.live.dynatrace.com) (current: $DT_TENANT_HOSTNAME) : " DT_TENANT_HOSTNAME_NEW
 read -p "Dynatrace API Token                                    (current: $DT_API_TOKEN) : " DT_API_TOKEN_NEW
 read -p "Dynatrace PaaS Token                                   (current: $DT_PAAS_TOKEN) : " DT_PAAS_TOKEN_NEW
 read -p "GitHub User Name                                       (current: $GITHUB_USER_NAME) : " GITHUB_USER_NAME_NEW
@@ -34,7 +34,7 @@ read -p "GitHub Organization                                    (current: $GITHU
 echo "==================================================================="
 echo ""
 # set value to new input or default to current value
-DT_TENANT_BASE_URL=${DT_TENANT_BASE_URL_NEW:-$DT_TENANT_BASE_URL}
+DT_TENANT_HOSTNAME=${DT_TENANT_HOSTNAME_NEW:-$DT_TENANT_HOSTNAME}
 DT_API_TOKEN=${DT_API_TOKEN_NEW:-$DT_API_TOKEN}
 DT_PAAS_TOKEN=${DT_PAAS_TOKEN_NEW:-$DT_PAAS_TOKEN}
 GITHUB_USER_NAME=${GITHUB_USER_NAME_NEW:-$GITHUB_USER_NAME}
@@ -43,7 +43,7 @@ GITHUB_USER_EMAIL=${GITHUB_USER_EMAIL_NEW:-$GITHUB_USER_EMAIL}
 GITHUB_ORGANIZATION=${GITHUB_ORGANIZATION_NEW:-$GITHUB_ORGANIZATION}
 
 echo -e "${YLW}Please confirm all are correct: ${NC}"
-echo "Dynatrace Tenant: $DT_TENANT_BASE_URL"
+echo "Dynatrace Tenant: $DT_TENANT_HOSTNAME"
 echo "Dynatrace API Token: $DT_API_TOKEN"
 echo "Dynatrace PaaS Token: $DT_PAAS_TOKEN"
 echo "GitHub User Name: $GITHUB_USER_NAME"
@@ -58,7 +58,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]
 then
     cp $CREDS $CREDS.bak 2> /dev/null
     rm $CREDS 2> /dev/null
-    cat ./creds.sav | sed 's~DYNATRACE_BASEURL_PLACEHOLDER~'"$DT_TENANT_BASE_URL"'~' | \
+    cat ./creds.sav | sed 's~DT_TENANT_HOSTNAME_PLACEHOLDER~'"$DT_TENANT_HOSTNAME"'~' | \
       sed 's~DYNATRACE_API_TOKEN~'"$DT_API_TOKEN"'~' | \
       sed 's~DYNATRACE_PAAS_TOKEN~'"$DT_PAAS_TOKEN"'~' | \
       sed 's~GITHUB_USER_NAME_PLACEHOLDER~'"$GITHUB_USER_NAME"'~' | \

--- a/scripts/4-setupInfrastructure.sh
+++ b/scripts/4-setupInfrastructure.sh
@@ -97,7 +97,7 @@ sleep 150
 
 #echo "----------------------------------------------------"
 #echo "Deploying Istio ..."
-#./setupIstio.sh $DT_TENANT_ID $DT_PAAS_TOKEN
+#./setupIstio.sh $DT_TENANT_BASE_URL $DT_PAAS_TOKEN
 
 echo "===================================================="
 echo "Finished setting up demo app infrastructure "

--- a/scripts/4-setupInfrastructure.sh
+++ b/scripts/4-setupInfrastructure.sh
@@ -97,7 +97,7 @@ sleep 150
 
 #echo "----------------------------------------------------"
 #echo "Deploying Istio ..."
-#./setupIstio.sh $DT_TENANT_BASE_URL $DT_PAAS_TOKEN
+#./setupIstio.sh $DT_TENANT_HOSTNAME $DT_PAAS_TOKEN
 
 echo "===================================================="
 echo "Finished setting up demo app infrastructure "

--- a/scripts/applyAutoTaggingRules.sh
+++ b/scripts/applyAutoTaggingRules.sh
@@ -24,7 +24,7 @@ echo "Checking if $DT_RULE_NAME exists ..."
 echo "----------------------------------------------------"
 export DT_ID=
 export DT_ID=$(curl -X GET \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_ID/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   | jq -r '.values[] | select(.name == "'$DT_RULE_NAME'") | .id')
@@ -36,7 +36,7 @@ then
   echo "Deleting $DT_RULE_NAME since exists (ID = $DT_ID) ..."
   echo "----------------------------------------------------"
   curl -X DELETE \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/autoTags/$DT_ID?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_ID/api/config/v1/autoTags/$DT_ID?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache'
 fi
@@ -45,7 +45,7 @@ echo "----------------------------------------------------"
 echo "Adding $DT_RULE_NAME ..."
 echo "----------------------------------------------------"
 curl -X POST \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_ID/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{
@@ -86,7 +86,7 @@ echo "Checking if $DT_RULE_NAME exists ..."
 echo "----------------------------------------------------"
 export DT_ID=
 export DT_ID=$(curl -X GET \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_ID/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   | jq -r '.values[] | select(.name == "'$DT_RULE_NAME'") | .id')
@@ -98,7 +98,7 @@ then
   echo "Deleting $DT_RULE_NAME since exists (ID = $DT_ID) ..."
   echo "----------------------------------------------------"
   curl -X DELETE \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/autoTags/$DT_ID?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_ID/api/config/v1/autoTags/$DT_ID?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache'
 fi
@@ -107,7 +107,7 @@ echo "----------------------------------------------------"
 echo "Adding $DT_RULE_NAME ..."
 echo "----------------------------------------------------"
 curl -X POST \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_ID/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{

--- a/scripts/applyAutoTaggingRules.sh
+++ b/scripts/applyAutoTaggingRules.sh
@@ -7,12 +7,12 @@ exec > >(tee -i $LOG_LOCATION/applyAutoTaggingRules.log)
 exec 2>&1
 
 
-export DT_TENANT_ID=$(cat creds.json | jq -r '.dynatraceTenant')
+export DT_TENANT_BASE_URL=$(cat creds.json | jq -r '.dynatraceBaseURL')
 export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
 
 echo "----------------------------------------------------"
 echo "Setting up auto tagging rules in your Dynatrace tenant."
-echo DT_TENANT_ID = $DT_TENANT_ID
+echo DT_TENANT_BASE_URL = $DT_TENANT_BASE_URL
 echo DT_API_TOKEN = $DT_API_TOKEN
 
 export DT_RULE_NAME=dt-kube-demo-service
@@ -24,7 +24,7 @@ echo "Checking if $DT_RULE_NAME exists ..."
 echo "----------------------------------------------------"
 export DT_ID=
 export DT_ID=$(curl -X GET \
-  "https://$DT_TENANT_ID/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_BASE_URL/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   | jq -r '.values[] | select(.name == "'$DT_RULE_NAME'") | .id')
@@ -36,7 +36,7 @@ then
   echo "Deleting $DT_RULE_NAME since exists (ID = $DT_ID) ..."
   echo "----------------------------------------------------"
   curl -X DELETE \
-  "https://$DT_TENANT_ID/api/config/v1/autoTags/$DT_ID?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_BASE_URL/api/config/v1/autoTags/$DT_ID?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache'
 fi
@@ -45,7 +45,7 @@ echo "----------------------------------------------------"
 echo "Adding $DT_RULE_NAME ..."
 echo "----------------------------------------------------"
 curl -X POST \
-  "https://$DT_TENANT_ID/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_BASE_URL/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{
@@ -86,7 +86,7 @@ echo "Checking if $DT_RULE_NAME exists ..."
 echo "----------------------------------------------------"
 export DT_ID=
 export DT_ID=$(curl -X GET \
-  "https://$DT_TENANT_ID/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_BASE_URL/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   | jq -r '.values[] | select(.name == "'$DT_RULE_NAME'") | .id')
@@ -98,7 +98,7 @@ then
   echo "Deleting $DT_RULE_NAME since exists (ID = $DT_ID) ..."
   echo "----------------------------------------------------"
   curl -X DELETE \
-  "https://$DT_TENANT_ID/api/config/v1/autoTags/$DT_ID?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_BASE_URL/api/config/v1/autoTags/$DT_ID?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache'
 fi
@@ -107,7 +107,7 @@ echo "----------------------------------------------------"
 echo "Adding $DT_RULE_NAME ..."
 echo "----------------------------------------------------"
 curl -X POST \
-  "https://$DT_TENANT_ID/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_BASE_URL/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{

--- a/scripts/applyAutoTaggingRules.sh
+++ b/scripts/applyAutoTaggingRules.sh
@@ -7,12 +7,12 @@ exec > >(tee -i $LOG_LOCATION/applyAutoTaggingRules.log)
 exec 2>&1
 
 
-export DT_TENANT_BASE_URL=$(cat creds.json | jq -r '.dynatraceBaseURL')
+export DT_TENANT_HOSTNAME=$(cat creds.json | jq -r '.dynatraceHostName')
 export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
 
 echo "----------------------------------------------------"
 echo "Setting up auto tagging rules in your Dynatrace tenant."
-echo DT_TENANT_BASE_URL = $DT_TENANT_BASE_URL
+echo DT_TENANT_HOSTNAME = $DT_TENANT_HOSTNAME
 echo DT_API_TOKEN = $DT_API_TOKEN
 
 export DT_RULE_NAME=dt-kube-demo-service
@@ -24,7 +24,7 @@ echo "Checking if $DT_RULE_NAME exists ..."
 echo "----------------------------------------------------"
 export DT_ID=
 export DT_ID=$(curl -X GET \
-  "https://$DT_TENANT_BASE_URL/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_HOSTNAME/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   | jq -r '.values[] | select(.name == "'$DT_RULE_NAME'") | .id')
@@ -36,7 +36,7 @@ then
   echo "Deleting $DT_RULE_NAME since exists (ID = $DT_ID) ..."
   echo "----------------------------------------------------"
   curl -X DELETE \
-  "https://$DT_TENANT_BASE_URL/api/config/v1/autoTags/$DT_ID?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_HOSTNAME/api/config/v1/autoTags/$DT_ID?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache'
 fi
@@ -45,7 +45,7 @@ echo "----------------------------------------------------"
 echo "Adding $DT_RULE_NAME ..."
 echo "----------------------------------------------------"
 curl -X POST \
-  "https://$DT_TENANT_BASE_URL/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_HOSTNAME/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{
@@ -86,7 +86,7 @@ echo "Checking if $DT_RULE_NAME exists ..."
 echo "----------------------------------------------------"
 export DT_ID=
 export DT_ID=$(curl -X GET \
-  "https://$DT_TENANT_BASE_URL/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_HOSTNAME/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   | jq -r '.values[] | select(.name == "'$DT_RULE_NAME'") | .id')
@@ -98,7 +98,7 @@ then
   echo "Deleting $DT_RULE_NAME since exists (ID = $DT_ID) ..."
   echo "----------------------------------------------------"
   curl -X DELETE \
-  "https://$DT_TENANT_BASE_URL/api/config/v1/autoTags/$DT_ID?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_HOSTNAME/api/config/v1/autoTags/$DT_ID?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache'
 fi
@@ -107,7 +107,7 @@ echo "----------------------------------------------------"
 echo "Adding $DT_RULE_NAME ..."
 echo "----------------------------------------------------"
 curl -X POST \
-  "https://$DT_TENANT_BASE_URL/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_HOSTNAME/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{

--- a/scripts/applyManagementZones.sh
+++ b/scripts/applyManagementZones.sh
@@ -5,12 +5,12 @@ LOG_LOCATION=./logs
 exec > >(tee -i $LOG_LOCATION/applyManagementZones.log)
 exec 2>&1
 
-export DT_TENANT_BASE_URL=$(cat creds.json | jq -r '.dynatraceBaseURL')
+export DT_TENANT_HOSTNAME=$(cat creds.json | jq -r '.dynatraceHostName')
 export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
 
 echo "----------------------------------------------------"
 echo "Apply auto tagging rules in Dynatrace ..."
-echo DT_TENANT_BASE_URL = $DT_TENANT_BASE_URL
+echo DT_TENANT_HOSTNAME = $DT_TENANT_HOSTNAME
 echo DT_API_TOKEN = $DT_API_TOKEN
 echo "----------------------------------------------------"
 
@@ -23,7 +23,7 @@ echo "Checking if $DT_ZONE_NAME exists ..."
 echo "----------------------------------------------------"
 export DT_ID=
 export DT_ID=$(curl -X GET \
-  "https://$DT_TENANT_BASE_URL/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_HOSTNAME/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   | jq -r '.values[] | select(.name == "'$DT_ZONE_NAME'") | .id')
@@ -35,7 +35,7 @@ then
   echo "Deleting $DT_ZONE_NAME since exists ..."
   echo "----------------------------------------------------"
   curl -X DELETE \
-  "https://$DT_TENANT_BASE_URL/api/config/v1/managementZones/$DT_ID?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_HOSTNAME/api/config/v1/managementZones/$DT_ID?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache'
 fi
@@ -44,7 +44,7 @@ echo "----------------------------------------------------"
 echo "Adding $DT_ZONE_NAME ..."
 echo "----------------------------------------------------"
 curl -X POST \
-  "https://$DT_TENANT_BASE_URL/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_HOSTNAME/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{
@@ -82,7 +82,7 @@ echo "Checking if $DT_ZONE_NAME exists ..."
 echo "----------------------------------------------------"
 export DT_ID=
 export DT_ID=$(curl -X GET \
-  "https://$DT_TENANT_BASE_URL/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_HOSTNAME/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   | jq -r '.values[] | select(.name == "'$DT_ZONE_NAME'") | .id')
@@ -94,7 +94,7 @@ then
   echo "Deleting $DT_ZONE_NAME since exists ..."
   echo "----------------------------------------------------"
   curl -X DELETE \
-  "https://$DT_TENANT_BASE_URL/api/config/v1/managementZones/$DT_ID?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_HOSTNAME/api/config/v1/managementZones/$DT_ID?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache'
 fi
@@ -103,7 +103,7 @@ echo "----------------------------------------------------"
 echo "Adding $DT_ZONE_NAME ..."
 echo "----------------------------------------------------"
 curl -X POST \
-  "https://$DT_TENANT_BASE_URL/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_HOSTNAME/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{

--- a/scripts/applyManagementZones.sh
+++ b/scripts/applyManagementZones.sh
@@ -5,12 +5,12 @@ LOG_LOCATION=./logs
 exec > >(tee -i $LOG_LOCATION/applyManagementZones.log)
 exec 2>&1
 
-export DT_TENANT_ID=$(cat creds.json | jq -r '.dynatraceTenant')
+export DT_TENANT_BASE_URL=$(cat creds.json | jq -r '.dynatraceBaseURL')
 export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
 
 echo "----------------------------------------------------"
 echo "Apply auto tagging rules in Dynatrace ..."
-echo DT_TENANT_ID = $DT_TENANT_ID
+echo DT_TENANT_BASE_URL = $DT_TENANT_BASE_URL
 echo DT_API_TOKEN = $DT_API_TOKEN
 echo "----------------------------------------------------"
 
@@ -23,7 +23,7 @@ echo "Checking if $DT_ZONE_NAME exists ..."
 echo "----------------------------------------------------"
 export DT_ID=
 export DT_ID=$(curl -X GET \
-  "https://$DT_TENANT_ID/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_BASE_URL/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   | jq -r '.values[] | select(.name == "'$DT_ZONE_NAME'") | .id')
@@ -35,7 +35,7 @@ then
   echo "Deleting $DT_ZONE_NAME since exists ..."
   echo "----------------------------------------------------"
   curl -X DELETE \
-  "https://$DT_TENANT_ID/api/config/v1/managementZones/$DT_ID?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_BASE_URL/api/config/v1/managementZones/$DT_ID?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache'
 fi
@@ -44,7 +44,7 @@ echo "----------------------------------------------------"
 echo "Adding $DT_ZONE_NAME ..."
 echo "----------------------------------------------------"
 curl -X POST \
-  "https://$DT_TENANT_ID/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_BASE_URL/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{
@@ -82,7 +82,7 @@ echo "Checking if $DT_ZONE_NAME exists ..."
 echo "----------------------------------------------------"
 export DT_ID=
 export DT_ID=$(curl -X GET \
-  "https://$DT_TENANT_ID/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_BASE_URL/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   | jq -r '.values[] | select(.name == "'$DT_ZONE_NAME'") | .id')
@@ -94,7 +94,7 @@ then
   echo "Deleting $DT_ZONE_NAME since exists ..."
   echo "----------------------------------------------------"
   curl -X DELETE \
-  "https://$DT_TENANT_ID/api/config/v1/managementZones/$DT_ID?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_BASE_URL/api/config/v1/managementZones/$DT_ID?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache'
 fi
@@ -103,7 +103,7 @@ echo "----------------------------------------------------"
 echo "Adding $DT_ZONE_NAME ..."
 echo "----------------------------------------------------"
 curl -X POST \
-  "https://$DT_TENANT_ID/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_BASE_URL/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{

--- a/scripts/applyManagementZones.sh
+++ b/scripts/applyManagementZones.sh
@@ -23,7 +23,7 @@ echo "Checking if $DT_ZONE_NAME exists ..."
 echo "----------------------------------------------------"
 export DT_ID=
 export DT_ID=$(curl -X GET \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_ID/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   | jq -r '.values[] | select(.name == "'$DT_ZONE_NAME'") | .id')
@@ -35,7 +35,7 @@ then
   echo "Deleting $DT_ZONE_NAME since exists ..."
   echo "----------------------------------------------------"
   curl -X DELETE \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/managementZones/$DT_ID?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_ID/api/config/v1/managementZones/$DT_ID?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache'
 fi
@@ -44,7 +44,7 @@ echo "----------------------------------------------------"
 echo "Adding $DT_ZONE_NAME ..."
 echo "----------------------------------------------------"
 curl -X POST \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_ID/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{
@@ -82,7 +82,7 @@ echo "Checking if $DT_ZONE_NAME exists ..."
 echo "----------------------------------------------------"
 export DT_ID=
 export DT_ID=$(curl -X GET \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_ID/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   | jq -r '.values[] | select(.name == "'$DT_ZONE_NAME'") | .id')
@@ -94,7 +94,7 @@ then
   echo "Deleting $DT_ZONE_NAME since exists ..."
   echo "----------------------------------------------------"
   curl -X DELETE \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/managementZones/$DT_ID?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_ID/api/config/v1/managementZones/$DT_ID?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache'
 fi
@@ -103,7 +103,7 @@ echo "----------------------------------------------------"
 echo "Adding $DT_ZONE_NAME ..."
 echo "----------------------------------------------------"
 curl -X POST \
-  "https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
+  "https://$DT_TENANT_ID/api/config/v1/managementZones?Api-Token=$DT_API_TOKEN" \
   -H 'Content-Type: application/json' \
   -H 'cache-control: no-cache' \
   -d '{

--- a/scripts/createIstionServiceEntry.sh
+++ b/scripts/createIstionServiceEntry.sh
@@ -4,7 +4,7 @@ LOG_LOCATION=./logs
 exec > >(tee -i $LOG_LOCATION/createIstionServiceEntry.log)
 exec 2>&1
 
-entries=$(curl https://$1.live.dynatrace.com/api/v1/deployment/installer/agent/connectioninfo?Api-Token=$2 | jq -r '.communicationEndpoints[]')
+entries=$(curl https://$1/api/v1/deployment/installer/agent/connectioninfo?Api-Token=$2 | jq -r '.communicationEndpoints[]')
 
 mkdir se_tmp
 touch se_tmp/hosts
@@ -13,8 +13,8 @@ touch se_tmp/service_entries
 
 cat ../manifests/istio/service_entries_tpl/part1 >> se_tmp/service_entries_oneagent.yml
 
-echo -e "  - $1.live.dynatrace.com" >> se_tmp/hosts
-cat ../manifests/istio/service_entry_tmpl | sed 's~ENDPOINT_PLACEHOLDER~'"$1"'.live.dynatrace.com~' >> se_tmp/service_entries
+echo -e "  - $1" >> se_tmp/hosts
+cat ../manifests/istio/service_entry_tmpl | sed 's~ENDPOINT_PLACEHOLDER~'"$1"'~' >> se_tmp/service_entries
 
 for row in $entries; do
     row=$(echo $row | sed 's~https://~~')

--- a/scripts/creds.sav
+++ b/scripts/creds.sav
@@ -2,7 +2,7 @@
     "jenkinsPort": "24711",
     "jenkinsUser": "admin",
     "jenkinsPassword": "AiTx4u8VyUV8tCKk",
-    "dynatraceTenant": "DYNATRACE_TENANT_PLACEHOLDER",
+    "dynatraceBaseURL": "DYNATRACE_BASEURL_PLACEHOLDER",
     "dynatraceApiToken": "DYNATRACE_API_TOKEN",
     "dynatracePaaSToken": "DYNATRACE_PAAS_TOKEN",
     "githubUserName": "GITHUB_USER_NAME_PLACEHOLDER",

--- a/scripts/creds.sav
+++ b/scripts/creds.sav
@@ -2,7 +2,7 @@
     "jenkinsPort": "24711",
     "jenkinsUser": "admin",
     "jenkinsPassword": "AiTx4u8VyUV8tCKk",
-    "dynatraceBaseURL": "DYNATRACE_BASEURL_PLACEHOLDER",
+    "dynatraceHostName": "DT_TENANT_HOSTNAME_PLACEHOLDER",
     "dynatraceApiToken": "DYNATRACE_API_TOKEN",
     "dynatracePaaSToken": "DYNATRACE_PAAS_TOKEN",
     "githubUserName": "GITHUB_USER_NAME_PLACEHOLDER",

--- a/scripts/setupDynatrace.sh
+++ b/scripts/setupDynatrace.sh
@@ -34,7 +34,7 @@ if [ $OK -eq 0 ]; then
   exit 1
 fi
 
-export DT_TENANT_BASE_URL=$(cat creds.json | jq -r '.dynatraceBaseURL')
+export DT_TENANT_HOSTNAME=$(cat creds.json | jq -r '.dynatraceHostName')
 export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
 export DT_PAAS_TOKEN=$(cat creds.json | jq -r '.dynatracePaaSToken')
 
@@ -69,6 +69,6 @@ fi
 
 mkdir -p ../manifests/gen/dynatrace
 curl -o ../manifests/gen/dynatrace/cr.yml https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/$DT_LATEST_RELEASE/deploy/cr.yaml
-cat ../manifests/gen/dynatrace/cr.yml | sed 's/ENVIRONMENTID.live.dynatrace.com/'"$DT_TENANT_BASE_URL"'/' >> ../manifests/gen/cr.yml
+cat ../manifests/gen/dynatrace/cr.yml | sed 's/ENVIRONMENTID.live.dynatrace.com/'"$DT_TENANT_HOSTNAME"'/' >> ../manifests/gen/cr.yml
 
 kubectl create -f ../manifests/gen/cr.yml

--- a/scripts/setupDynatrace.sh
+++ b/scripts/setupDynatrace.sh
@@ -69,6 +69,6 @@ fi
 
 mkdir -p ../manifests/gen/dynatrace
 curl -o ../manifests/gen/dynatrace/cr.yml https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/$DT_LATEST_RELEASE/deploy/cr.yaml
-cat ../manifests/gen/dynatrace/cr.yml | sed 's/ENVIRONMENTID/'"$DT_TENANT_ID"'/' >> ../manifests/gen/cr.yml
+cat ../manifests/gen/dynatrace/cr.yml | sed 's/ENVIRONMENTID.live.dynatrace.com/'"$DT_TENANT_ID"'/' >> ../manifests/gen/cr.yml
 
 kubectl create -f ../manifests/gen/cr.yml

--- a/scripts/setupDynatrace.sh
+++ b/scripts/setupDynatrace.sh
@@ -34,7 +34,7 @@ if [ $OK -eq 0 ]; then
   exit 1
 fi
 
-export DT_TENANT_ID=$(cat creds.json | jq -r '.dynatraceTenant')
+export DT_TENANT_BASE_URL=$(cat creds.json | jq -r '.dynatraceBaseURL')
 export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
 export DT_PAAS_TOKEN=$(cat creds.json | jq -r '.dynatracePaaSToken')
 
@@ -69,6 +69,6 @@ fi
 
 mkdir -p ../manifests/gen/dynatrace
 curl -o ../manifests/gen/dynatrace/cr.yml https://raw.githubusercontent.com/Dynatrace/dynatrace-oneagent-operator/$DT_LATEST_RELEASE/deploy/cr.yaml
-cat ../manifests/gen/dynatrace/cr.yml | sed 's/ENVIRONMENTID.live.dynatrace.com/'"$DT_TENANT_ID"'/' >> ../manifests/gen/cr.yml
+cat ../manifests/gen/dynatrace/cr.yml | sed 's/ENVIRONMENTID.live.dynatrace.com/'"$DT_TENANT_BASE_URL"'/' >> ../manifests/gen/cr.yml
 
 kubectl create -f ../manifests/gen/cr.yml

--- a/scripts/setupIstio.sh
+++ b/scripts/setupIstio.sh
@@ -4,7 +4,7 @@ LOG_LOCATION=./logs
 exec > >(tee -i $LOG_LOCATION/setupIstio.log)
 exec 2>&1
 
-DT_TENANT_ID=$1
+DT_TENANT_BASE_URL=$1
 DT_PAAS_TOKEN=$2
 
 kubectl apply -f ../manifests/istio/crds.yml
@@ -16,4 +16,4 @@ kubectl label namespace production istio-injection=enabled
 
 kubectl create -f ../manifests/istio/istio-gateway.yml
 
-./createIstionServiceEntry.sh $DT_TENANT_ID $DT_PAAS_TOKEN
+./createIstionServiceEntry.sh $DT_TENANT_BASE_URL $DT_PAAS_TOKEN

--- a/scripts/setupIstio.sh
+++ b/scripts/setupIstio.sh
@@ -4,7 +4,7 @@ LOG_LOCATION=./logs
 exec > >(tee -i $LOG_LOCATION/setupIstio.log)
 exec 2>&1
 
-DT_TENANT_BASE_URL=$1
+DT_TENANT_HOSTNAME=$1
 DT_PAAS_TOKEN=$2
 
 kubectl apply -f ../manifests/istio/crds.yml
@@ -16,4 +16,4 @@ kubectl label namespace production istio-injection=enabled
 
 kubectl create -f ../manifests/istio/istio-gateway.yml
 
-./createIstionServiceEntry.sh $DT_TENANT_BASE_URL $DT_PAAS_TOKEN
+./createIstionServiceEntry.sh $DT_TENANT_HOSTNAME $DT_PAAS_TOKEN

--- a/scripts/setupJenkins.sh
+++ b/scripts/setupJenkins.sh
@@ -38,7 +38,7 @@ export GITHUB_USER_EMAIL=$(cat creds.json | jq -r '.githubUserEmail')
 export GITHUB_ORGANIZATION=$(cat creds.json | jq -r '.githubOrg')
 export REGISTRY_URL=$(cat creds.json | jq -r '.registry')
 export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
-export DT_TENANT_BASE_URL=$(cat creds.json | jq -r '.dynatraceBaseURL')
+export DT_TENANT_HOSTNAME=$(cat creds.json | jq -r '.dynatraceHostName')
 
 
 echo "----------------------------------------------------"
@@ -52,7 +52,7 @@ if [ $DEPLOYMENT == ocp ]; then
     sed 's~GITHUB_USER_EMAIL_PLACEHOLDER~'"$GITHUB_USER_EMAIL"'~' | \
     sed 's~GITHUB_ORGANIZATION_PLACEHOLDER~'"$GITHUB_ORGANIZATION"'~' | \
     sed 's~DOCKER_REGISTRY_IP_PLACEHOLDER~'"$REGISTRY_URL"'~' | \
-    sed 's~DT_TENANT_URL_PLACEHOLDER~'"$DT_TENANT_BASE_URL"'~' | \
+    sed 's~DT_TENANT_URL_PLACEHOLDER~'"$DT_TENANT_HOSTNAME"'~' | \
     sed 's~DT_API_TOKEN_PLACEHOLDER~'"$DT_API_TOKEN"'~' >> ../manifests/gen/ocp-jenkins-deployment.yml
   oc create -f ../manifest/jenkins/ocp-jenkins-pvcs.yml
   oc create -f ../manifests/gen/ocp-jenkins-deployment.yml
@@ -62,7 +62,7 @@ else
     sed 's~GITHUB_USER_EMAIL_PLACEHOLDER~'"$GITHUB_USER_EMAIL"'~' | \
     sed 's~GITHUB_ORGANIZATION_PLACEHOLDER~'"$GITHUB_ORGANIZATION"'~' | \
     sed 's~DOCKER_REGISTRY_IP_PLACEHOLDER~'"$REGISTRY_URL"'~' | \
-    sed 's~DT_TENANT_URL_PLACEHOLDER~'"$DT_TENANT_BASE_URL"'~' | \
+    sed 's~DT_TENANT_URL_PLACEHOLDER~'"$DT_TENANT_HOSTNAME"'~' | \
     sed 's~DT_API_TOKEN_PLACEHOLDER~'"$DT_API_TOKEN"'~' >> ../manifests/gen/k8s-jenkins-deployment.yml
   kubectl create -f ../manifests/jenkins/k8s-jenkins-pvcs.yml 
   kubectl create -f ../manifests/gen/k8s-jenkins-deployment.yml

--- a/scripts/setupJenkins.sh
+++ b/scripts/setupJenkins.sh
@@ -39,7 +39,7 @@ export GITHUB_ORGANIZATION=$(cat creds.json | jq -r '.githubOrg')
 export REGISTRY_URL=$(cat creds.json | jq -r '.registry')
 export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
 export DT_TENANT_ID=$(cat creds.json | jq -r '.dynatraceTenant')
-export DT_TENANT_URL="$DT_TENANT_ID.live.dynatrace.com"
+
 
 echo "----------------------------------------------------"
 echo "Deploying Jenkins ..."
@@ -52,7 +52,7 @@ if [ $DEPLOYMENT == ocp ]; then
     sed 's~GITHUB_USER_EMAIL_PLACEHOLDER~'"$GITHUB_USER_EMAIL"'~' | \
     sed 's~GITHUB_ORGANIZATION_PLACEHOLDER~'"$GITHUB_ORGANIZATION"'~' | \
     sed 's~DOCKER_REGISTRY_IP_PLACEHOLDER~'"$REGISTRY_URL"'~' | \
-    sed 's~DT_TENANT_URL_PLACEHOLDER~'"$DT_TENANT_URL"'~' | \
+    sed 's~DT_TENANT_URL_PLACEHOLDER~'"$DT_TENANT_ID"'~' | \
     sed 's~DT_API_TOKEN_PLACEHOLDER~'"$DT_API_TOKEN"'~' >> ../manifests/gen/ocp-jenkins-deployment.yml
   oc create -f ../manifest/jenkins/ocp-jenkins-pvcs.yml
   oc create -f ../manifests/gen/ocp-jenkins-deployment.yml
@@ -62,7 +62,7 @@ else
     sed 's~GITHUB_USER_EMAIL_PLACEHOLDER~'"$GITHUB_USER_EMAIL"'~' | \
     sed 's~GITHUB_ORGANIZATION_PLACEHOLDER~'"$GITHUB_ORGANIZATION"'~' | \
     sed 's~DOCKER_REGISTRY_IP_PLACEHOLDER~'"$REGISTRY_URL"'~' | \
-    sed 's~DT_TENANT_URL_PLACEHOLDER~'"$DT_TENANT_URL"'~' | \
+    sed 's~DT_TENANT_URL_PLACEHOLDER~'"$DT_TENANT_ID"'~' | \
     sed 's~DT_API_TOKEN_PLACEHOLDER~'"$DT_API_TOKEN"'~' >> ../manifests/gen/k8s-jenkins-deployment.yml
   kubectl create -f ../manifests/jenkins/k8s-jenkins-pvcs.yml 
   kubectl create -f ../manifests/gen/k8s-jenkins-deployment.yml

--- a/scripts/setupJenkins.sh
+++ b/scripts/setupJenkins.sh
@@ -38,7 +38,7 @@ export GITHUB_USER_EMAIL=$(cat creds.json | jq -r '.githubUserEmail')
 export GITHUB_ORGANIZATION=$(cat creds.json | jq -r '.githubOrg')
 export REGISTRY_URL=$(cat creds.json | jq -r '.registry')
 export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
-export DT_TENANT_ID=$(cat creds.json | jq -r '.dynatraceTenant')
+export DT_TENANT_BASE_URL=$(cat creds.json | jq -r '.dynatraceBaseURL')
 
 
 echo "----------------------------------------------------"
@@ -52,7 +52,7 @@ if [ $DEPLOYMENT == ocp ]; then
     sed 's~GITHUB_USER_EMAIL_PLACEHOLDER~'"$GITHUB_USER_EMAIL"'~' | \
     sed 's~GITHUB_ORGANIZATION_PLACEHOLDER~'"$GITHUB_ORGANIZATION"'~' | \
     sed 's~DOCKER_REGISTRY_IP_PLACEHOLDER~'"$REGISTRY_URL"'~' | \
-    sed 's~DT_TENANT_URL_PLACEHOLDER~'"$DT_TENANT_ID"'~' | \
+    sed 's~DT_TENANT_URL_PLACEHOLDER~'"$DT_TENANT_BASE_URL"'~' | \
     sed 's~DT_API_TOKEN_PLACEHOLDER~'"$DT_API_TOKEN"'~' >> ../manifests/gen/ocp-jenkins-deployment.yml
   oc create -f ../manifest/jenkins/ocp-jenkins-pvcs.yml
   oc create -f ../manifests/gen/ocp-jenkins-deployment.yml
@@ -62,7 +62,7 @@ else
     sed 's~GITHUB_USER_EMAIL_PLACEHOLDER~'"$GITHUB_USER_EMAIL"'~' | \
     sed 's~GITHUB_ORGANIZATION_PLACEHOLDER~'"$GITHUB_ORGANIZATION"'~' | \
     sed 's~DOCKER_REGISTRY_IP_PLACEHOLDER~'"$REGISTRY_URL"'~' | \
-    sed 's~DT_TENANT_URL_PLACEHOLDER~'"$DT_TENANT_ID"'~' | \
+    sed 's~DT_TENANT_URL_PLACEHOLDER~'"$DT_TENANT_BASE_URL"'~' | \
     sed 's~DT_API_TOKEN_PLACEHOLDER~'"$DT_API_TOKEN"'~' >> ../manifests/gen/k8s-jenkins-deployment.yml
   kubectl create -f ../manifests/jenkins/k8s-jenkins-pvcs.yml 
   kubectl create -f ../manifests/gen/k8s-jenkins-deployment.yml

--- a/scripts/validateDynatrace.sh
+++ b/scripts/validateDynatrace.sh
@@ -11,7 +11,7 @@ echo "==========================="
 export DT_TENANT_ID=$(cat creds.json | jq -r '.dynatraceTenant')
 export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
 export DT_PAAS_TOKEN=$(cat creds.json | jq -r '.dynatracePaaSToken')
-export DT_TENANT_URL="$DT_TENANT_ID.live.dynatrace.com"
+
 
 if [ $DT_TENANT_ID == "DYNATRACE_TENANT_PLACEHOLDER" ]
 then
@@ -33,7 +33,7 @@ echo ""
 echo "----------------------------------------------------------"
 echo Validating Dynatrace PaaS token is configured properly ...
 echo "----------------------------------------------------------"
-export DT_URL="https://$DT_TENANT_ID.live.dynatrace.com/api/v1/time?Api-Token=$DT_PAAS_TOKEN"
+export DT_URL="https://$DT_TENANT_ID/api/v1/time?Api-Token=$DT_PAAS_TOKEN"
 if [ "$(curl -sL -w '%{http_code}' $DT_URL -o /dev/null)" != "200" ]
 
 then
@@ -46,7 +46,7 @@ echo ""
 echo "----------------------------------------------------------"
 echo Validating Dynatrace API token is configured properly ...
 echo "----------------------------------------------------------"
-export DT_URL="https://$DT_TENANT_ID.live.dynatrace.com/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN"
+export DT_URL="https://$DT_TENANT_ID/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN"
 if [ "$(curl -sL -w '%{http_code}' $DT_URL -o /dev/null)" != "200" ]
 then
     echo ">>> Unable to connect using API Token.  Verify you have the right API Token"

--- a/scripts/validateDynatrace.sh
+++ b/scripts/validateDynatrace.sh
@@ -8,14 +8,14 @@ echo "==========================="
 echo Validating Dynatrace 
 echo "==========================="
 
-export DT_TENANT_BASE_URL=$(cat creds.json | jq -r '.dynatraceBaseURL')
+export DT_TENANT_HOSTNAME=$(cat creds.json | jq -r '.dynatraceHostName')
 export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
 export DT_PAAS_TOKEN=$(cat creds.json | jq -r '.dynatracePaaSToken')
 
 
-if [ $DT_TENANT_BASE_URL == "DYNATRACE_BASEURL_PLACEHOLDER" ]
+if [ $DT_TENANT_HOSTNAME == "DT_TENANT_HOSTNAME_PLACEHOLDER" ]
 then
-  echo DT_TENANT_BASE_URL is not set properly.
+  echo DT_TENANT_HOSTNAME is not set properly.
   exit 1
 fi
 if [ $DT_API_TOKEN == "DYNATRACE_API_TOKEN" ]
@@ -33,7 +33,7 @@ echo ""
 echo "----------------------------------------------------------"
 echo Validating Dynatrace PaaS token is configured properly ...
 echo "----------------------------------------------------------"
-export DT_URL="https://$DT_TENANT_BASE_URL/api/v1/time?Api-Token=$DT_PAAS_TOKEN"
+export DT_URL="https://$DT_TENANT_HOSTNAME/api/v1/time?Api-Token=$DT_PAAS_TOKEN"
 if [ "$(curl -sL -w '%{http_code}' $DT_URL -o /dev/null)" != "200" ]
 
 then
@@ -46,7 +46,7 @@ echo ""
 echo "----------------------------------------------------------"
 echo Validating Dynatrace API token is configured properly ...
 echo "----------------------------------------------------------"
-export DT_URL="https://$DT_TENANT_BASE_URL/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN"
+export DT_URL="https://$DT_TENANT_HOSTNAME/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN"
 if [ "$(curl -sL -w '%{http_code}' $DT_URL -o /dev/null)" != "200" ]
 then
     echo ">>> Unable to connect using API Token.  Verify you have the right API Token"

--- a/scripts/validateDynatrace.sh
+++ b/scripts/validateDynatrace.sh
@@ -8,14 +8,14 @@ echo "==========================="
 echo Validating Dynatrace 
 echo "==========================="
 
-export DT_TENANT_ID=$(cat creds.json | jq -r '.dynatraceTenant')
+export DT_TENANT_BASE_URL=$(cat creds.json | jq -r '.dynatraceBaseURL')
 export DT_API_TOKEN=$(cat creds.json | jq -r '.dynatraceApiToken')
 export DT_PAAS_TOKEN=$(cat creds.json | jq -r '.dynatracePaaSToken')
 
 
-if [ $DT_TENANT_ID == "DYNATRACE_TENANT_PLACEHOLDER" ]
+if [ $DT_TENANT_BASE_URL == "DYNATRACE_BASEURL_PLACEHOLDER" ]
 then
-  echo DT_TENANT_ID is not set properly.
+  echo DT_TENANT_BASE_URL is not set properly.
   exit 1
 fi
 if [ $DT_API_TOKEN == "DYNATRACE_API_TOKEN" ]
@@ -33,7 +33,7 @@ echo ""
 echo "----------------------------------------------------------"
 echo Validating Dynatrace PaaS token is configured properly ...
 echo "----------------------------------------------------------"
-export DT_URL="https://$DT_TENANT_ID/api/v1/time?Api-Token=$DT_PAAS_TOKEN"
+export DT_URL="https://$DT_TENANT_BASE_URL/api/v1/time?Api-Token=$DT_PAAS_TOKEN"
 if [ "$(curl -sL -w '%{http_code}' $DT_URL -o /dev/null)" != "200" ]
 
 then
@@ -46,7 +46,7 @@ echo ""
 echo "----------------------------------------------------------"
 echo Validating Dynatrace API token is configured properly ...
 echo "----------------------------------------------------------"
-export DT_URL="https://$DT_TENANT_ID/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN"
+export DT_URL="https://$DT_TENANT_BASE_URL/api/config/v1/autoTags?Api-Token=$DT_API_TOKEN"
 if [ "$(curl -sL -w '%{http_code}' $DT_URL -o /dev/null)" != "200" ]
 then
     echo ">>> Unable to connect using API Token.  Verify you have the right API Token"


### PR DESCRIPTION
Made changes to allow for usage in any instance of dynatrace (saas, managed, dev, lab, etc) by changing the DT_TENANT_ID to be the full domain instead of just the first 8 identifier. 
I was able to test end to end with all exercises using eksctl, but could not test using terraform as, even using the origin setup-infra repo, the 3-provisionInfrastructure script fails for unknown reasons. 

Not only does this remove all references to 'live.dynatrace.com', but it also modifies the sed command in setupDynatrace to replace the full default placeholder. 